### PR TITLE
Support for externs (for advanced optimizations)

### DIFF
--- a/index.js
+++ b/index.js
@@ -173,7 +173,6 @@ UberCompiler.prototype.compileJsFinal_ = function(soyJsPath) {
     jsCmd += ' --js ' + soyJsPath;
   }
   jsCmd += ' > ' + path.join(this.outputDir, this.getJsFilename());
-  util.log(jsCmd);
   childProcess.exec(jsCmd, _.bind(function(error, stdout, stderr) {
     if (stderr && stderr.length) {
       util.error(stderr);


### PR DESCRIPTION
If you're using advanced optimizations and third-party frameworks not compatible with that mode, you need externs. I've treated them almost as the regular js files (with watchers for changes etc.), but send them with the --externs flag to the closure compiler.
